### PR TITLE
prevent an infinite loop

### DIFF
--- a/src/cover.js
+++ b/src/cover.js
@@ -16,7 +16,7 @@ export default function(x, y) {
 
   // Otherwise, double repeatedly to cover.
   else {
-    var z = x1 - x0,
+    var z = x1 - x0 || 1,
         node = this._root,
         parent,
         i;

--- a/test/cover-test.js
+++ b/test/cover-test.js
@@ -77,3 +77,8 @@ tape("quadtree.cover(x, y) does not wrap the root node if it is undefined", func
   test.equal(q.copy().cover(-3, -3).root(), undefined);
   test.end();
 });
+
+tape("quadtree.cover() does not crash on huge values", function(test) {
+  d3_quadtree.quadtree([[1e23, 0]]);
+  test.end();
+});


### PR DESCRIPTION
The situation happens in force simulations when a point is horribly far (maybe because of a programming error, or because we set the wrong parameters on an experimental force). Then forceCollide calls quadtree(nodes, x,,y), which tries to cover by repeatedly doubling z=0. This ends up crashing the browser.